### PR TITLE
Use the plotly.js version that corresponds to plotly.py being used

### DIFF
--- a/fh_plotly/p2fh.py
+++ b/fh_plotly/p2fh.py
@@ -2,11 +2,12 @@ from dataclasses import dataclass
 from typing import Optional
 from uuid import uuid4
 from plotly.io import to_json
+from plotly.offline._plotlyjs_version import __plotlyjs_version__ as plotlyjs_version
 from fasthtml.common import Div, Script
 
 
 plotly_headers = [
-    Script(src="https://cdn.plot.ly/plotly-latest.min.js"),
+    Script(src=f"https://cdn.plot.ly/plotly-{plotlyjs_version}.min.js"),
     Script(
         """
     const fhPlotlyRegisterOnClick = (plotId, hxPostEndpoint, hxTarget) => {


### PR DESCRIPTION
Changes the src URL of `plotly_headers` to the one that corresponds to the version used by plotly.py installed.

Ref #2